### PR TITLE
Add docker file for lab work

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:18.04
+
+# Install the required development packages
+RUN apt-get update && apt-get install -y \
+    cmake \
+    gcc \
+    g++ \
+    git \
+    curl \
+    vim \
+    python3 \
+    python3-pip \
+    protobuf-compiler \
+    libprotoc-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# Set up to use python3 and pip3 as default for python and pip
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+
+# Upgrade pip
+RUN pip install --upgrade pip
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,15 +1,31 @@
 ## Prerequisites
 
-Follow the instructions on [Install Docker](https://docs.docker.com/engine/installation/) to install docker for your machine.
+Follow the instructions in [Docker Docs](https://docs.docker.com/engine/installation/) to install docker for your machine.
 
 ## Prepare the image
 
 Switch to `docker` directory here and run (don't miss the dot at the end of the command!)
 
 ```
-docker build -t onnx-dev-env .
+sudo docker build -t onnx-dev-env .
 ```
 
 After the build is complete you will have `onnx-dev-env` image that you can use for your work with ONNX in this repository
 
+## Start up a new container using the image
 
+In this example, `onnx-dojo-lab` is the name of the new container being spawned up
+
+```
+sudo docker run -idt --name onnx-dojo-lab onnx-dev-env
+```
+
+## Get into the newly created container to start with your lab exercise
+
+Here we start the bash shell inside the container
+
+```
+sudo docker exec -it onnx-dojo-lab /bin/bash
+```
+
+Voila! Now you are ready to start with your lab exercises.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,15 @@
+## Prerequisites
+
+Follow the instructions on [Install Docker](https://docs.docker.com/engine/installation/) to install docker for your machine.
+
+## Prepare the image
+
+Switch to `docker` directory here and run (don't miss the dot at the end of the command!)
+
+```
+docker build -t onnx-dev-env .
+```
+
+After the build is complete you will have `onnx-dev-env` image that you can use for your work with ONNX in this repository
+
+


### PR DESCRIPTION
Add Dockerfile to create a docker image that can be used for the hands-on lab exercise for the participants who already have docker installed.